### PR TITLE
[INTER-1196] Add optional heading to plugin configuration

### DIFF
--- a/src/@types/pluginConfig.ts
+++ b/src/@types/pluginConfig.ts
@@ -12,4 +12,5 @@ export default interface PluginConfig {
   iOS?: IOSPlatformConfiguration
   /** @deprecated Use `platforms.android` instead */
   android?: AndroidPlatformConfiguration
+  heading?: string
 }

--- a/src/generateNotes.ts
+++ b/src/generateNotes.ts
@@ -37,13 +37,21 @@ const generateNotes = async (config: PluginConfig, ctx: GenerateNotesContext) =>
     ctx.logger.log(`Detected iOS Version: \`${iOSVersion}\``)
   }
 
-  return Object.keys(platformVersions)
+  let notes = ''
+
+  if (config.heading) {
+    notes += `### ${config.heading}\n\n`
+  }
+
+  notes += Object.keys(platformVersions)
     .map((platformKey) => {
       const platform = platformKey as keyof PlatformConfig
       const version = platformVersions[platform]
       return `${platforms[platform]?.displayName ?? platform} Version Range: **\`${version}\`**`
     })
     .join('\n\n')
+
+  return notes
 }
 
 export default generateNotes

--- a/src/generateNotes.ts
+++ b/src/generateNotes.ts
@@ -25,15 +25,15 @@ const generateNotes = async (config: PluginConfig, ctx: GenerateNotesContext) =>
     throw new Error('No platforms specified. You must configure at least one platform under `platforms`.')
   }
 
-  if (platforms['android']) {
-    const androidVersion = await androidResolve(ctx, platforms['android'])
-    platformVersions['android'] = androidVersion
+  if (platforms.android) {
+    const androidVersion = await androidResolve(ctx, platforms.android)
+    platformVersions.android = androidVersion
     ctx.logger.log(`Detected Android Version: \`${androidVersion}\``)
   }
 
-  if (platforms['iOS']) {
-    const iOSVersion = await iOSResolve(ctx, platforms['iOS'])
-    platformVersions['iOS'] = iOSVersion
+  if (platforms.iOS) {
+    const iOSVersion = await iOSResolve(ctx, platforms.iOS)
+    platformVersions.iOS = iOSVersion
     ctx.logger.log(`Detected iOS Version: \`${iOSVersion}\``)
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -108,5 +108,32 @@ describe('index', () => {
     it('throws error when no platform specified', async () => {
       await expect(generateNotes({}, generateNotesContext)).rejects.toThrowErrorMatchingSnapshot('noPlatform')
     })
+    it('adds heading when specified', async () => {
+      const heading = 'Example Heading'
+      const { iOS, android } = pluginConfig.platforms
+
+      const expectedHeading = `### ${heading}`
+      const expectedAndroid = `${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
+      const expectedIOS = `${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
+
+      const subTestCases = [
+        {
+          platforms: { iOS, android },
+          expected: [expectedHeading, expectedAndroid, expectedIOS].join('\n\n'),
+        },
+        {
+          platforms: { iOS },
+          expected: [expectedHeading, expectedIOS].join('\n\n'),
+        },
+        {
+          platforms: { android },
+          expected: [expectedHeading, expectedAndroid].join('\n\n'),
+        },
+      ]
+
+      for (const { platforms, expected } of subTestCases) {
+        await expect(generateNotes({ platforms, heading }, generateNotesContext)).resolves.toBe(expected)
+      }
+    }, 30000)
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -108,7 +108,7 @@ describe('index', () => {
     it('throws error when no platform specified', async () => {
       await expect(generateNotes({}, generateNotesContext)).rejects.toThrowErrorMatchingSnapshot('noPlatform')
     })
-    it('adds heading when specified', async () => {
+    describe('heading', () => {
       const heading = 'Example Heading'
       const { iOS, android } = pluginConfig.platforms
 
@@ -131,9 +131,19 @@ describe('index', () => {
         },
       ]
 
-      for (const { platforms, expected } of subTestCases) {
-        await expect(generateNotes({ platforms, heading }, generateNotesContext)).resolves.toBe(expected)
-      }
-    }, 30000)
+      subTestCases.forEach((testCase) => {
+        it(`adds heading when specified for platforms: ${Object.keys(testCase.platforms).join(', ')}`, async () => {
+          await expect(
+            generateNotes(
+              {
+                platforms: testCase.platforms,
+                heading,
+              },
+              generateNotesContext
+            )
+          ).resolves.toBe(testCase.expected)
+        }, 30000)
+      })
+    })
   })
 })


### PR DESCRIPTION
This update adds support for an optional `heading` field in the plugin configuration. If a `heading` is provided, it will appear at the top of the generated release notes as an H3 heading (`###`).

## ✅ What's Changed?

- Added `heading?: string` to the PluginConfig type.
- Updated `generateNotes` to prepend the heading (if set) before the dependency version info.
- Added tests to make sure the heading is correctly included.

## ✏️ How To Test?

1. Add a `heading` field to your plugin config, for example:
```
...
{
  heading: "Supported Native Versions",
  platforms: {
    ...
  }
}
...
```
2. Trigger semantic release in `dryRun` mode.
3. You should see the heading prepended in the output.