### PR TITLE
[INTER-1190] Add plugin configuration reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ Add the plugin to your `.releaserc` configuration:
 
 ### Plugin Configuration Reference
 
-| Key                                | Type     | Description                                                                  |
-|------------------------------------|----------|------------------------------------------------------------------------------|
-| `heading`                          | `string` | Optional h3 heading shown before listing platform specific version ranges.   |
-| `platforms`                        | `object` | Top-level object defining configuration for each platform.                   |
-| `platforms.iOS`                    | `object` | Configuration for the iOS dependency version resolution.                     |
-| `platforms.iOS.podSpecJsonPath`    | `string` | Path to the PODSPEC json file containing iOS dependency metadata.            |
-| `platforms.iOS.dependencyName`     | `string` | Name of the dependency to extract the version.                               |
-| `platforms.iOS.displayName`        | `string` | Name for the iOS dependency shown in release notes.                          |
-| `platforms.android`                | `object` | Configuration for the Android dependency version resolution.                 |
-| `platforms.android.path`           | `string` | Relative path to the Android project directory which contains `build.gradle. |
-| `platforms.android.gradleTaskName` | `string` | Name of the custom Gradle task that outputs the dependency version.          |
-| `platforms.android.displayName`    | `string` | Name for the Android dependency shown in release notes.                      |
+| Key                                | Type     | Default   | Description                                                                  |
+|------------------------------------|----------|-----------|------------------------------------------------------------------------------|
+| `heading`                          | `string` |           | Optional h3 heading shown before listing platform specific version ranges.   |
+| `platforms`                        | `object` |           | Top-level object defining configuration for each platform.                   |
+| `platforms.iOS`                    | `object` |           | Configuration for the iOS dependency version resolution.                     |
+| `platforms.iOS.podSpecJsonPath`    | `string` |           | Path to the PODSPEC json file containing iOS dependency metadata.            |
+| `platforms.iOS.dependencyName`     | `string` |           | Name of the dependency to extract the version.                               |
+| `platforms.iOS.displayName`        | `string` | `iOS`     | Name for the iOS dependency shown in release notes.                          |
+| `platforms.android`                | `object` |           | Configuration for the Android dependency version resolution.                 |
+| `platforms.android.path`           | `string` |           | Relative path to the Android project directory which contains `build.gradle. |
+| `platforms.android.gradleTaskName` | `string` |           | Name of the custom Gradle task that outputs the dependency version.          |
+| `platforms.android.displayName`    | `string` | `android` | Name for the Android dependency shown in release notes.                      |
 
 > **Note:** You can configure one or both platforms depending on your project needs. At least one platform
 > (`iOS` or `android`) must be configured. The plugin will throw an error if both are omitted.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Add the plugin to your `.releaserc` configuration:
 }
 ```
 
+### Plugin Configuration Reference
+
+| Key                                | Type     | Description                                                                  |
+|------------------------------------|----------|------------------------------------------------------------------------------|
+| `platforms`                        | `object` | Top-level object defining configuration for each platform.                   |
+| `platforms.iOS`                    | `object` | Configuration for the iOS dependency version resolution.                     |
+| `platforms.iOS.podSpecJsonPath`    | `string` | Path to the PODSPEC json file containing iOS dependency metadata.            |
+| `platforms.iOS.dependencyName`     | `string` | Name of the dependency to extract the version.                               |
+| `platforms.iOS.displayName`        | `string` | Name for the iOS dependency shown in release notes.                          |
+| `platforms.android`                | `object` | Configuration for the Android dependency version resolution.                 |
+| `platforms.android.path`           | `string` | Relative path to the Android project directory which contains `build.gradle. |
+| `platforms.android.gradleTaskName` | `string` | Name of the custom Gradle task that outputs the dependency version.          |
+| `platforms.android.displayName`    | `string` | Name for the Android dependency shown in release notes.                      |
+
+> **Note:** You can configure one or both platforms depending on your project needs. At least one platform
+> (`iOS` or `android`) must be configured. The plugin will throw an error if both are omitted.
+
 ## How It Works
 
 - The plugin reads version information from podspec json file (iOS) and/or a custom Gradle task output (Android).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Add the plugin to your `.releaserc` configuration:
 
 | Key                                | Type     | Description                                                                  |
 |------------------------------------|----------|------------------------------------------------------------------------------|
+| `heading`                          | `string` | Optional h3 heading shown before listing platform specific version ranges.   |
 | `platforms`                        | `object` | Top-level object defining configuration for each platform.                   |
 | `platforms.iOS`                    | `object` | Configuration for the iOS dependency version resolution.                     |
 | `platforms.iOS.podSpecJsonPath`    | `string` | Path to the PODSPEC json file containing iOS dependency metadata.            |


### PR DESCRIPTION
This update improves the `README.md` file by adding a `Plugin Configuration Reference` section. It provides a clear and structured table of configuration keys required to set up the plugin for iOS and Android platforms.

## ✅ What's Changed?

- A table explaining each configuration key, its type, and its purpose (description).
- Notes on platform-specific setup and warning about configuring at least one platform.

## 🔍  Why?

To improve developer experience and ensure easier onboarding and configuration of the plugin.