### PR TITLE
[INTER-1190] Add example for generated release notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Add the plugin to your `.releaserc` configuration:
     [
       "@fingerprintjs/semantic-release-native-dependency-plugin",
       {
+        "heading": "Supported Native SDK Version Range",
         "platforms": {
           "iOS": {
             "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
@@ -60,6 +61,8 @@ Example generated release notes:
 ### Features
 
 * example feat release ([018455b](https://github.com/.../commit/...))
+
+### Supported Native SDK Version Range
 
 Fingerprint Android SDK Version Range: `>= 2.7.0 and < 3.0.0`
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Add the plugin to your `.releaserc` configuration:
 - It automatically includes the extracted versions in the release notes.
 - Helps maintain transparency about dependency versions used in each release.
 
+Example generated release notes:
+
+```markdown
+## 3.4.0 (https://github.com/.../compare/v3.3.1...v3.4.0) (2025-04-10)
+
+### Features
+
+* example feat release ([018455b](https://github.com/.../commit/...))
+
+Fingerprint Android SDK Version Range: `>= 2.7.0 and < 3.0.0`
+
+Fingerprint iOS SDK Version Range: `>= 2.7.0 and < 3.0.0`
+```
+
 ## Requirements
 
 - Node.js 20.8.1 or higher


### PR DESCRIPTION
This update adds a simple example of what the generated release notes look like when using the plugin. It shows how version ranges are included in the release notes.

This should make it easier for users to understand what to expect from the plugin's output.