### PR TITLE
[INTER-1190] Extract note generation into a formatter function

### DIFF
--- a/src/generateNotes.ts
+++ b/src/generateNotes.ts
@@ -3,9 +3,23 @@ import PluginConfig, { PlatformConfig } from './@types/pluginConfig'
 import { resolve as androidResolve } from './platforms/android'
 import { resolve as iOSResolve } from './platforms/iOS'
 
-const generateNotes = async (config: PluginConfig, ctx: GenerateNotesContext) => {
-  const platformVersions: { [key in keyof PlatformConfig]?: string } = {}
+const formatter = (platforms: { displayName: string; versionRange: string }[], heading?: string) => {
+  let result = ''
 
+  if (heading) {
+    result += `### ${heading}\n\n`
+  }
+
+  result += platforms
+    .map(({ displayName, versionRange }) => {
+      return `${displayName} Version Range: **\`${versionRange}\`**`
+    })
+    .join('\n\n')
+
+  return result
+}
+
+const generateNotes = async (config: PluginConfig, ctx: GenerateNotesContext) => {
   // Normalize plugin config: prefer `platforms`, fall back to legacy top-level platform keys for backward compatibility
   // TODO: Remove support for top-level `android` and `iOS` keys in the next major release (BC)
   const platforms: PlatformConfig = config.platforms || {}
@@ -25,33 +39,27 @@ const generateNotes = async (config: PluginConfig, ctx: GenerateNotesContext) =>
     throw new Error('No platforms specified. You must configure at least one platform under `platforms`.')
   }
 
+  const platformVersions: { displayName: string; versionRange: string }[] = []
+
   if (platforms.android) {
     const androidVersion = await androidResolve(ctx, platforms.android)
-    platformVersions.android = androidVersion
+    platformVersions.push({
+      displayName: platforms.android.displayName ?? 'Android',
+      versionRange: androidVersion,
+    })
     ctx.logger.log(`Detected Android Version: \`${androidVersion}\``)
   }
 
   if (platforms.iOS) {
     const iOSVersion = await iOSResolve(ctx, platforms.iOS)
-    platformVersions.iOS = iOSVersion
+    platformVersions.push({
+      displayName: platforms.iOS.displayName ?? 'iOS',
+      versionRange: iOSVersion,
+    })
     ctx.logger.log(`Detected iOS Version: \`${iOSVersion}\``)
   }
 
-  let notes = ''
-
-  if (config.heading) {
-    notes += `### ${config.heading}\n\n`
-  }
-
-  notes += Object.keys(platformVersions)
-    .map((platformKey) => {
-      const platform = platformKey as keyof PlatformConfig
-      const version = platformVersions[platform]
-      return `${platforms[platform]?.displayName ?? platform} Version Range: **\`${version}\`**`
-    })
-    .join('\n\n')
-
-  return notes
+  return formatter(platformVersions, config.heading)
 }
 
 export default generateNotes


### PR DESCRIPTION
This refactor simplifies the way release notes are generated by adding a new `formatter` function. It takes care of formatting platform versions and optionally adds a heading if one is provided.

## ✅ What's Changed?

- Moved version formatting logic into its own `formatter` function.
- Made generateNotes easier to read and maintain (simplified).
- Still supports the optional `heading` in the same way.
- Keeps the output exactly the same, no behavioral changes.

This is purely a cleanup and doesn't affect how the plugin behaves or what it outputs. It just makes the code easier to work.