### PR TITLE
[INTER-1190] Include original error message when file read fails

### DIFF
--- a/src/platforms/iOS.ts
+++ b/src/platforms/iOS.ts
@@ -44,7 +44,7 @@ export const resolve = async (
       case 'EACCES':
         throw new Error(`${podSpecJsonPath} file cannot be accessed.`)
       default:
-        throw new Error(`${podSpecJsonPath} file cannot be read.`)
+        throw new Error(`${podSpecJsonPath} file cannot be read. Error: ${error.message}`)
     }
   }
 

--- a/test/__snapshots__/iOS.test.ts.snap
+++ b/test/__snapshots__/iOS.test.ts.snap
@@ -4,4 +4,4 @@ exports[`Test for iOS platform throws error when file not found: podspecFileNotF
 
 exports[`Test for iOS platform throws error when file not readable: podspecNotReadable 1`] = `"not-readable.podspec.json file cannot be accessed."`;
 
-exports[`Test for iOS platform throws error when path is a directory: podspecPathIsDirectory 1`] = `"test file cannot be read."`;
+exports[`Test for iOS platform throws error when path is a directory: podspecPathIsDirectory 1`] = `"test file cannot be read. Error: EISDIR: illegal operation on a directory, read"`;


### PR DESCRIPTION
Improved error handling for the iOS platform by including the original system error message when reading a podspec file fails. This provides more context for debugging issues like incorrect file types or permission problems (instead of hiding the actual error).

## ✅ What's Changed?

- Appended the underlying `error.message` to the error message for better visibility.
- Updated the relevant snapshot test.

This makes it easier to understand why a file read failed, especially in edge cases.