### PR TITLE
[INTER-1190] Format dependency version ranges in release notes as bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ Example generated release notes:
 
 ### Supported Native SDK Version Range
 
-Fingerprint Android SDK Version Range: `>= 2.7.0 and < 3.0.0`
-
-Fingerprint iOS SDK Version Range: `>= 2.7.0 and < 3.0.0`
+* Fingerprint Android SDK Version Range: `>= 2.7.0 and < 3.0.0`
+* Fingerprint iOS SDK Version Range: `>= 2.7.0 and < 3.0.0`
 ```
 
 ## Requirements

--- a/src/generateNotes.ts
+++ b/src/generateNotes.ts
@@ -12,9 +12,9 @@ const formatter = (platforms: { displayName: string; versionRange: string }[], h
 
   result += platforms
     .map(({ displayName, versionRange }) => {
-      return `${displayName} Version Range: **\`${versionRange}\`**`
+      return `* ${displayName} Version Range: **\`${versionRange}\`**`
     })
-    .join('\n\n')
+    .join('\n')
 
   return result
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,7 +42,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`* ${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     }, 30000)
     it('resolves android version (backport)', async () => {
       const android = pluginConfig.platforms.android
@@ -54,7 +54,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`* ${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     }, 30000)
     it('resolves iOS version', async () => {
       const iOS = pluginConfig.platforms.iOS
@@ -68,7 +68,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`* ${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     })
     it('resolves iOS version (backport)', async () => {
       const iOS = pluginConfig.platforms.iOS
@@ -80,7 +80,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`* ${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     })
     it('throws error on cwd not set', async () => {
       const testGenerateNotesContext = {
@@ -112,22 +112,22 @@ describe('index', () => {
       const heading = 'Example Heading'
       const { iOS, android } = pluginConfig.platforms
 
-      const expectedHeading = `### ${heading}`
-      const expectedAndroid = `${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
-      const expectedIOS = `${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
+      const expectedHeading = `### ${heading}\n`
+      const expectedAndroid = `* ${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
+      const expectedIOS = `* ${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`
 
       const subTestCases = [
         {
           platforms: { iOS, android },
-          expected: [expectedHeading, expectedAndroid, expectedIOS].join('\n\n'),
+          expected: [expectedHeading, expectedAndroid, expectedIOS].join('\n'),
         },
         {
           platforms: { iOS },
-          expected: [expectedHeading, expectedIOS].join('\n\n'),
+          expected: [expectedHeading, expectedIOS].join('\n'),
         },
         {
           platforms: { android },
-          expected: [expectedHeading, expectedAndroid].join('\n\n'),
+          expected: [expectedHeading, expectedAndroid].join('\n'),
         },
       ]
 


### PR DESCRIPTION
This PR updates the release notes formatting to list dependency version ranges as markdown bullet points (`*`) instead of new lines. This change improves readability and aligns the output style with common markdown formatting with other semantic release plugins (like `Features` and `Bugfixes` lists).

## ✅ What's Changed?

- Updated `generateNotes` to prepend each dependency version range with `*`
- Fixed related tests to expect the new format
- Updated the example release notes in the `README.md` file
