### PR TITLE
[INTER-1190] Add default heading for release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ Add the plugin to your `.releaserc` configuration:
 
 ### Plugin Configuration Reference
 
-| Key                                | Type     | Default   | Description                                                                  |
-|------------------------------------|----------|-----------|------------------------------------------------------------------------------|
-| `heading`                          | `string` |           | Optional h3 heading shown before listing platform specific version ranges.   |
-| `platforms`                        | `object` |           | Top-level object defining configuration for each platform.                   |
-| `platforms.iOS`                    | `object` |           | Configuration for the iOS dependency version resolution.                     |
-| `platforms.iOS.podSpecJsonPath`    | `string` |           | Path to the PODSPEC json file containing iOS dependency metadata.            |
-| `platforms.iOS.dependencyName`     | `string` |           | Name of the dependency to extract the version.                               |
-| `platforms.iOS.displayName`        | `string` | `iOS`     | Name for the iOS dependency shown in release notes.                          |
-| `platforms.android`                | `object` |           | Configuration for the Android dependency version resolution.                 |
-| `platforms.android.path`           | `string` |           | Relative path to the Android project directory which contains `build.gradle. |
-| `platforms.android.gradleTaskName` | `string` |           | Name of the custom Gradle task that outputs the dependency version.          |
-| `platforms.android.displayName`    | `string` | `android` | Name for the Android dependency shown in release notes.                      |
+| Key                                | Type     | Default               | Description                                                                  |
+|------------------------------------|----------|-----------------------|------------------------------------------------------------------------------|
+| `heading`                          | `string` | `Native Dependencies` | Optional h3 heading shown before listing platform specific version ranges.   |
+| `platforms`                        | `object` |                       | Top-level object defining configuration for each platform.                   |
+| `platforms.iOS`                    | `object` |                       | Configuration for the iOS dependency version resolution.                     |
+| `platforms.iOS.podSpecJsonPath`    | `string` |                       | Path to the PODSPEC json file containing iOS dependency metadata.            |
+| `platforms.iOS.dependencyName`     | `string` |                       | Name of the dependency to extract the version.                               |
+| `platforms.iOS.displayName`        | `string` | `iOS`                 | Name for the iOS dependency shown in release notes.                          |
+| `platforms.android`                | `object` |                       | Configuration for the Android dependency version resolution.                 |
+| `platforms.android.path`           | `string` |                       | Relative path to the Android project directory which contains `build.gradle. |
+| `platforms.android.gradleTaskName` | `string` |                       | Name of the custom Gradle task that outputs the dependency version.          |
+| `platforms.android.displayName`    | `string` | `android`             | Name for the Android dependency shown in release notes.                      |
 
 > **Note:** You can configure one or both platforms depending on your project needs. At least one platform
 > (`iOS` or `android`) must be configured. The plugin will throw an error if both are omitted.

--- a/src/generateNotes.ts
+++ b/src/generateNotes.ts
@@ -4,11 +4,7 @@ import { resolve as androidResolve } from './platforms/android'
 import { resolve as iOSResolve } from './platforms/iOS'
 
 const formatter = (platforms: { displayName: string; versionRange: string }[], heading?: string) => {
-  let result = ''
-
-  if (heading) {
-    result += `### ${heading}\n\n`
-  }
+  let result = `### ${heading ?? 'Native Dependencies'}\n\n`
 
   result += platforms
     .map(({ displayName, versionRange }) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,6 +27,8 @@ const generateNotesContext = {
 
 describe('index', () => {
   describe('generateNotes', () => {
+    const defaultHeading = '### Native Dependencies'
+
     it('is a function', () => {
       expect(generateNotes).toBeInstanceOf(Function)
     })
@@ -42,7 +44,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`${defaultHeading}\n\n${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     }, 30000)
     it('resolves android version (backport)', async () => {
       const android = pluginConfig.platforms.android
@@ -54,7 +56,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`${defaultHeading}\n\n${android.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     }, 30000)
     it('resolves iOS version', async () => {
       const iOS = pluginConfig.platforms.iOS
@@ -68,7 +70,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`${defaultHeading}\n\n${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     })
     it('resolves iOS version (backport)', async () => {
       const iOS = pluginConfig.platforms.iOS
@@ -80,7 +82,7 @@ describe('index', () => {
           },
           generateNotesContext
         )
-      ).resolves.toBe(`${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
+      ).resolves.toBe(`${defaultHeading}\n\n${iOS.displayName} Version Range: **\`>= 1.2.3 and < 4.5.6\`**`)
     })
     it('throws error on cwd not set', async () => {
       const testGenerateNotesContext = {


### PR DESCRIPTION
This PR adds a default heading ("Native Dependencies") to the generated release notes when the plugin configuration does not explicitly provide a `heading` value.

## 🤔 Why?

Previously, if no `heading` were set, the notes would begin without a section title. This change ensures more structured release notes by always prepending a section header.

## ✅ What's Changed?

- `generateNotes` function now uses `Native Dependencies` as a fallback for `heading` value.
- All related test cases are updated/fixed to reflect the default heading
- The plugin configuration table in the `README.md` has been updated to document the default value for `heading` field.
