### PR TITLE
Add podspec DSL support and deprecate outdated parameter

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -9,3 +9,5 @@ jobs:
       pull-requests: write
       contents: read
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/coverage-diff.yml@v1
+    with:
+      runsOn: 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 ## Overview
 
-This plugin retrieves native dependency version information from iOS and/or Android projects and integrates it into the semantic release workflow generate notes steps.
+This plugin retrieves native dependency version information from iOS and/or Android projects and integrates it into the
+semantic release workflow generate notes steps.
 
-- Extracts dependency versions from podspec json file (iOS) and/or Gradle task output (Android)
+- Extracts dependency versions from podspec file (iOS) and/or Gradle task output (Android)
 - Ensures version consistency in release notes
 - Automates version retrieval for better release documentation
 
@@ -31,7 +32,7 @@ Add the plugin to your `.releaserc` configuration:
         "heading": "Supported Native SDK Version Range",
         "platforms": {
           "iOS": {
-            "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+            "podSpecPath": "RNFingerprintjsPro.podspec.json",
             "dependencyName": "FingerprintPro",
             "displayName": "Fingerprint iOS SDK"
           },
@@ -54,7 +55,7 @@ Add the plugin to your `.releaserc` configuration:
 | `heading`                          | `string` | `Native Dependencies` | Optional h3 heading shown before listing platform specific version ranges.   |
 | `platforms`                        | `object` |                       | Top-level object defining configuration for each platform.                   |
 | `platforms.iOS`                    | `object` |                       | Configuration for the iOS dependency version resolution.                     |
-| `platforms.iOS.podSpecJsonPath`    | `string` |                       | Path to the PODSPEC json file containing iOS dependency metadata.            |
+| `platforms.iOS.podSpecPath`        | `string` |                       | Path to the PODSPEC file containing iOS dependency metadata.                 |
 | `platforms.iOS.dependencyName`     | `string` |                       | Name of the dependency to extract the version.                               |
 | `platforms.iOS.displayName`        | `string` | `iOS`                 | Name for the iOS dependency shown in release notes.                          |
 | `platforms.android`                | `object` |                       | Configuration for the Android dependency version resolution.                 |
@@ -67,7 +68,7 @@ Add the plugin to your `.releaserc` configuration:
 
 ## How It Works
 
-- The plugin reads version information from podspec json file (iOS) and/or a custom Gradle task output (Android).
+- The plugin reads version information from podspec file (iOS) and/or a custom Gradle task output (Android).
 - It automatically includes the extracted versions in the release notes.
 - Helps maintain transparency about dependency versions used in each release.
 
@@ -104,7 +105,6 @@ We welcome contributions! To get started with development:
 - **[Jest][jest]** for testing
 - **[Commitizen][commitizen]** for conventional commits
 
-
 ### Setup
 
 1. Clone the repository
@@ -127,7 +127,7 @@ We welcome contributions! To get started with development:
     ```shell
     pnpm start
     ```
-    or build the project manually:
+  or build the project manually:
     ```shell
     pnpm build
     ```
@@ -155,6 +155,9 @@ We welcome contributions! To get started with development:
 MIT
 
 [husky]: https://typicode.github.io/husky
+
 [lint-staged]: https://github.com/lint-staged/lint-staged
+
 [jest]: https://jestjs.io
+
 [commitizen]: https://commitizen-tools.github.io/commitizen

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,5 @@
+export class JsonParseError extends Error {
+  constructor(podspecFilePath: string) {
+    super(`${podspecFilePath} file cannot be parsed as JSON.`)
+  }
+}

--- a/src/gradle.ts
+++ b/src/gradle.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import { access, constants } from 'node:fs'
 import { exec } from 'node:child_process'
+import { isNotFoundErrorCode } from './utils'
 
 /**
  * Check if gradle is installed to system-wide.
@@ -12,8 +13,7 @@ export function isGradleAvailable(): Promise<boolean> {
   return new Promise((resolve, reject) => {
     exec('gradle --version', (err) => {
       if (err) {
-        // 127 means command not found (https://tldp.org/LDP/abs/html/exitcodes.html)
-        if (err.code === 127) {
+        if (isNotFoundErrorCode(err.code)) {
           resolve(false)
         }
         reject(err)

--- a/src/platforms/iOS.ts
+++ b/src/platforms/iOS.ts
@@ -3,22 +3,20 @@ import { readFileSync } from 'node:fs'
 import type { GenerateNotesContext } from 'semantic-release'
 
 export interface IOSPlatformConfiguration {
-  podSpecJsonPath: string | undefined
+  /**
+   * @deprecated use `podspecPath` instead
+   * */
+  podSpecJsonPath?: string | undefined
+  podspecPath: string | undefined
   dependencyName: string | undefined
   displayName: string | undefined
 }
 
-type PodspecJson = {
-  dependencies: {
-    [key: string]: [string]
-  }
-}
-
-export type IOSResolveContext = Pick<GenerateNotesContext, 'cwd'>
+export type IOSResolveContext = Pick<GenerateNotesContext, 'cwd' | 'logger'>
 
 export const resolve = async (
-  { cwd }: IOSResolveContext,
-  { podSpecJsonPath, dependencyName }: IOSPlatformConfiguration
+  { cwd, logger }: IOSResolveContext,
+  { podSpecJsonPath, podspecPath, dependencyName }: IOSPlatformConfiguration
 ) => {
   if (!cwd) {
     throw new Error(`Current working directory is required to detect iOS dependency version range.`)

--- a/src/platforms/iOS.ts
+++ b/src/platforms/iOS.ts
@@ -1,6 +1,8 @@
 import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
 import type { GenerateNotesContext } from 'semantic-release'
+import { isPodAvailable, podIpcSpec, PodspecJson } from '../pods'
+import { JsonParseError } from '../errors'
 
 export interface IOSPlatformConfiguration {
   /**
@@ -22,27 +24,62 @@ export const resolve = async (
     throw new Error(`Current working directory is required to detect iOS dependency version range.`)
   }
 
-  if (!podSpecJsonPath) {
-    throw new Error('iOS Podspec Json path should be defined.')
-  }
-
   if (!dependencyName) {
     throw new Error('iOS Dependency name should be defined.')
   }
 
-  const jsonFile = join(cwd, podSpecJsonPath)
+  let podspecPathParam: string | undefined
+  if (podspecPath) {
+    podspecPathParam = podspecPath
+  } else if (podSpecJsonPath) {
+    logger.warn('[DEPRECATED] Use `platforms.iOS.podspecPath` instead of `platform.iOS.podSpecJsonPath`.')
+    podspecPathParam = podSpecJsonPath
+  }
+  if (!podspecPathParam) {
+    throw new Error('iOS Podspec path should be defined.')
+  }
+
+  let podspecContents: PodspecJson | undefined
+
+  try {
+    podspecContents = readPodspecJson(cwd, podspecPathParam)
+  } catch (e) {
+    if (!(e instanceof JsonParseError)) {
+      throw e
+    }
+
+    podspecContents = await readPodspecDSL(podspecPathParam)
+  }
+
+  if (!podspecContents.dependencies || !podspecContents.dependencies[dependencyName]) {
+    throw new Error(`${podspecPathParam} file does not contain '${dependencyName}' in dependencies.`)
+  }
+
+  return podspecContents.dependencies[dependencyName].join(' and ')
+}
+
+function readPodspecDSL(podspecFilePath: string): Promise<PodspecJson> {
+  if (!isPodAvailable()) {
+    throw new Error(`Pods not found in your system.`)
+  }
+
+  return podIpcSpec(podspecFilePath)
+}
+
+function readPodspecJson(cwd: string, podspecFilePath: string): PodspecJson {
+  const resolvedPodspecPath = join(cwd, podspecFilePath)
 
   let fileContent: string
   try {
-    fileContent = readFileSync(jsonFile, 'utf8')
+    fileContent = readFileSync(resolvedPodspecPath, 'utf8')
   } catch (error: any) {
     switch (error.code) {
       case 'ENOENT':
-        throw new Error(`${podSpecJsonPath} file does not exist.`)
+        throw new Error(`${podspecFilePath} file does not exist.`)
       case 'EACCES':
-        throw new Error(`${podSpecJsonPath} file cannot be accessed.`)
+        throw new Error(`${podspecFilePath} file cannot be accessed.`)
       default:
-        throw new Error(`${podSpecJsonPath} file cannot be read. Error: ${error.message}`)
+        throw new Error(`${podspecFilePath} file cannot be read. Error: ${error.message}`)
     }
   }
 
@@ -50,12 +87,8 @@ export const resolve = async (
   try {
     data = JSON.parse(fileContent) as PodspecJson
   } catch (error) {
-    throw new Error(`${podSpecJsonPath} file cannot be parsed as JSON.`)
+    throw new JsonParseError(podspecFilePath)
   }
 
-  if (!data.dependencies || !data.dependencies[dependencyName]) {
-    throw new Error(`${podSpecJsonPath} file does not contain '${dependencyName}' in dependencies.`)
-  }
-
-  return data.dependencies[dependencyName].join(' and ')
+  return data
 }

--- a/src/pods.ts
+++ b/src/pods.ts
@@ -1,0 +1,53 @@
+import { exec } from 'child_process'
+import { isNotFoundErrorCode } from './utils'
+import { JsonParseError } from './errors'
+
+/**
+ * Checks whether CocoaPods are installed and available on the system by executing the `pod --version` command.
+ * Resolves to `true` if CocoaPods are available, resolves to `false` if CocoaPods are not installed,
+ * and rejects with an error if another issue occurs.
+ *
+ * @return {Promise<boolean>} A promise that resolves to `true` if CocoaPods are installed `false` otherwise.
+ */
+export function isPodAvailable(): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    exec('pod --version', (err) => {
+      if (err) {
+        if (isNotFoundErrorCode(err.code)) {
+          resolve(false)
+        }
+        reject(err)
+      }
+
+      resolve(true)
+    })
+  })
+}
+
+/**
+ * Executes the `pod ipc spec` command on the given podspec file and returns the parsed result as an object.
+ *
+ * @param {string} podspecFile - The path to the `.podspec` file to be processed.
+ * @return {Promise<PodspecJson>} A promise that resolves to the parsed PodspecJson object or rejects with an error if the command fails.
+ */
+export function podIpcSpec(podspecFile: string): Promise<PodspecJson> {
+  return new Promise<PodspecJson>((resolve, reject) => {
+    exec(`pod ipc spec ${podspecFile}`, (err, stdout) => {
+      if (err) {
+        reject(err)
+      }
+
+      try {
+        resolve(JSON.parse(stdout) as PodspecJson)
+      } catch {
+        throw new JsonParseError(podspecFile)
+      }
+    })
+  })
+}
+
+export type PodspecJson = {
+  dependencies: {
+    [key: string]: [string]
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,3 +8,8 @@ export function humanizeMavenStyleVersionRange(versionRange: string) {
     .replace(/\s*\[\s*(.*?)\s*]/g, '>=$1')
     .replace(/\s*\(\s*(.*?)\s*\)/g, '>$1')
 }
+
+export function isNotFoundErrorCode(code?: number) {
+  // 127 means command not found (https://tldp.org/LDP/abs/html/exitcodes.html)
+  return code === 127
+}

--- a/test/iOS.test.ts
+++ b/test/iOS.test.ts
@@ -1,16 +1,38 @@
 import { describe, expect, it } from '@jest/globals'
 import { cwd } from 'node:process'
 import { IOSResolveContext, resolve } from '../src/platforms/iOS'
+import { Signale } from 'signale'
 
 describe('Test for iOS platform', () => {
+  const logger = new Signale({ disabled: true })
   const dependencyName = 'FingerprintPro'
   const ctx = {
     cwd: cwd(),
+    logger,
   } satisfies IOSResolveContext
 
-  it('returns correct version', async () => {
+  it('returns correct version with json', async () => {
+    const iosVersion = await resolve(ctx, {
+      podspecPath: 'test/project/ios/podspec.json',
+      dependencyName,
+      displayName: undefined,
+    })
+    expect(iosVersion).toBe('>= 1.2.3 and < 4.5.6')
+  })
+
+  it('returns correct version with json using deprecated podSpecJsonPath', async () => {
+    //@ts-expect-error
     const iosVersion = await resolve(ctx, {
       podSpecJsonPath: 'test/project/ios/podspec.json',
+      dependencyName,
+      displayName: undefined,
+    })
+    expect(iosVersion).toBe('>= 1.2.3 and < 4.5.6')
+  })
+
+  it('returns correct version with dsl', async () => {
+    const iosVersion = await resolve(ctx, {
+      podspecPath: 'test/project/ios/Test.podspec',
       dependencyName,
       displayName: undefined,
     })
@@ -20,7 +42,7 @@ describe('Test for iOS platform', () => {
   it('throws error when file not found', async () => {
     await expect(
       resolve(ctx, {
-        podSpecJsonPath: 'nonExists',
+        podspecPath: 'nonExists',
         dependencyName,
         displayName: undefined,
       })
@@ -34,7 +56,7 @@ describe('Test for iOS platform', () => {
     })
 
     await expect(
-      resolve(ctx, { podSpecJsonPath: 'not-readable.podspec.json', dependencyName, displayName: undefined })
+      resolve(ctx, { podspecPath: 'not-readable.podspec.json', dependencyName, displayName: undefined })
     ).rejects.toThrowErrorMatchingSnapshot('podspecNotReadable')
 
     readFileSyncMock.mockRestore()
@@ -43,7 +65,7 @@ describe('Test for iOS platform', () => {
   it('throws error when path is a directory', async () => {
     await expect(
       resolve(ctx, {
-        podSpecJsonPath: 'test',
+        podspecPath: 'test',
         dependencyName,
         displayName: undefined,
       })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ const cwd = process.cwd()
 const pluginConfig = {
   platforms: {
     iOS: {
-      podSpecJsonPath: 'test/project/ios/podspec.json',
+      podspecPath: 'test/project/ios/podspec.json',
       dependencyName: 'FingerprintPro',
       displayName: 'Fingerprint iOS SDK',
     },

--- a/test/pods.test.ts
+++ b/test/pods.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from '@jest/globals'
+import { isPodAvailable, podIpcSpec } from '../src/pods'
+import { JsonParseError } from '../src/errors'
+
+describe('Test for pod utils', () => {
+  describe('isPodAvailable function', () => {
+    it('return false with DSL format if pod command is not available', async () => {
+      const execMock = jest.spyOn(require('node:child_process'), 'exec')
+      execMock.mockImplementation((command, callback) => {
+        if (command === 'pod --version') {
+          // @ts-ignore
+          callback({ code: 127 })
+        }
+      })
+
+      await expect(isPodAvailable()).resolves.toBe(false)
+    })
+
+    it('throws on unknown error', async () => {
+      const execMock = jest.spyOn(require('node:child_process'), 'exec')
+      execMock.mockImplementation((command, callback) => {
+        if (command === 'pod --version') {
+          // @ts-ignore
+          callback(new Error('Unknown error'))
+        }
+      })
+
+      await expect(isPodAvailable()).rejects.toThrow('Unknown error')
+    })
+  })
+
+  describe('podIpcSpec function', () => {
+    it('parses valid podspec JSON successfully', async () => {
+      const validJson = JSON.stringify({ dependencies: { Dependency: ['1.0'] } })
+      const execMock = jest.spyOn(require('node:child_process'), 'exec')
+      execMock.mockImplementation((command, callback) => {
+        if ((command as string).startsWith('pod ipc spec')) {
+          // @ts-ignore
+          callback(null, validJson)
+        }
+      })
+
+      const result = await podIpcSpec('MyPod.podspec')
+      expect(result).toEqual({ dependencies: { Dependency: ['1.0'] } })
+    })
+
+    it('throws a JsonParseError when JSON is invalid', async () => {
+      const invalidJson = '{ invalid json '
+      const execMock = jest.spyOn(require('node:child_process'), 'exec')
+      execMock.mockImplementation((command, callback) => {
+        if ((command as string).startsWith('pod ipc spec')) {
+          // @ts-ignore
+          callback(null, invalidJson)
+        }
+      })
+
+      await expect(podIpcSpec('InvalidPod.podspec')).rejects.toThrow(JsonParseError)
+    })
+
+    it('throws an error when the command fails', async () => {
+      const execMock = jest.spyOn(require('node:child_process'), 'exec')
+      execMock.mockImplementation((command, callback) => {
+        if ((command as string).startsWith('pod ipc spec')) {
+          // @ts-ignore
+          callback(new Error('Command failed'))
+        }
+      })
+
+      await expect(podIpcSpec('ErrorPod.podspec')).rejects.toThrow('Command failed')
+    })
+  })
+})

--- a/test/project/ios/Test.podspec
+++ b/test/project/ios/Test.podspec
@@ -1,0 +1,6 @@
+Pod::Spec.new do |s|
+  s.name         = "RNFingerprintjsPro"
+
+  s.dependency "React-Core"
+  s.dependency "FingerprintPro", '>= 1.2.3', '< 4.5.6'
+end


### PR DESCRIPTION
- Introduced support for specifying podspec via DSL format by using `pod ipc spec`
- Deprecated the `platforms.iOS.podSpecJsonPath` parameter, replacing it with `platforms.iOS.podspecPath`.