### PR TITLE
ci: run release action on macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       appId: ${{ vars.APP_ID }}
       distFolderNeedForRelease: true
+      runsOn: 'macos-latest'
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Use macos-latest on release action to make the tests pass.