### PR TITLE
Make Android/iOS path handling work for non-root repos

### DIFF
--- a/src/platforms/android.ts
+++ b/src/platforms/android.ts
@@ -23,7 +23,7 @@ async function runGradleTask(
 
   return new Promise((resolve, reject) => {
     const child = spawn(command, [androidGradleTaskName, '-q', '--console=plain'], {
-      cwd: androidPath,
+      cwd: androidFullPath,
       env,
       detached: true,
       stdio: ['inherit', 'pipe', 'pipe'],

--- a/src/platforms/iOS.ts
+++ b/src/platforms/iOS.ts
@@ -48,7 +48,8 @@ export const resolve = async (
       throw e
     }
 
-    podspecContents = await readPodspecDSL(podspecPathParam)
+    const podspecDSLPath = join(cwd, podspecPathParam)
+    podspecContents = await readPodspecDSL(podspecDSLPath)
   }
 
   if (!podspecContents.dependencies || !podspecContents.dependencies[dependencyName]) {


### PR DESCRIPTION
This cleans up a path issue that showed up in non-root setups:
- **Android**: run Gradle with `cwd: androidFullPath` instead of the root-relative `androidPath`.
- **iOS**: resolve the podspec absolute path.

## ❓ Why?

Running the tool from a nested directory could cause _"file not found”_  / _wrong `cwd` path resolution_. These changes make the commands work no matter where the projects live.